### PR TITLE
Bug: UserRegistry 수정

### DIFF
--- a/src/main/java/org/improvejava/kurento_chat/UserRegistry.java
+++ b/src/main/java/org/improvejava/kurento_chat/UserRegistry.java
@@ -11,9 +11,11 @@ public class UserRegistry {
   Logger logger = Logger.getLogger(UserRegistry.class.getName());
 
   private final ConcurrentHashMap<String, UserSession> userSessionByUserId = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, UserSession> userSessionBySessionId = new ConcurrentHashMap<>();
 
   public void register(UserSession user) {
-    userSessionByUserId.put(user.getSession().getId(), user);
+    userSessionByUserId.put(user.getUserId(), user);
+    userSessionBySessionId.put(user.getSession().getId(), user);
   }
 
   public UserSession getByUserId(String userId) {
@@ -21,7 +23,7 @@ public class UserRegistry {
   }
 
   public UserSession getBySession(WebSocketSession session) {
-    return userSessionByUserId.get(session.getId());
+    return userSessionBySessionId.get(session.getId());
   }
 
   public boolean exists(String userId) {


### PR DESCRIPTION
잘못된 UserRegistry 로직으로 인해 새로운 사용자인지 기존의 사용자인지
판단하고 UserSession을 가져올 때 문제가 발생하는 부분 수정

기존 코드의 문제
- UserRegistry 저장 시 잘못된 방식으로 저장함